### PR TITLE
Fix wrong position taken by DrawerButton on linux

### DIFF
--- a/lib/presentation/layout/puzzle_layout.dart
+++ b/lib/presentation/layout/puzzle_layout.dart
@@ -85,7 +85,8 @@ class PuzzleLayout implements LayoutDelegate {
       Positioned(
         top: kIsWeb
             ? Spacing.md
-            : !kIsWeb && (Platform.isAndroid || Platform.isMacOS)
+            : !kIsWeb &&
+                    (Platform.isAndroid || Platform.isMacOS || Platform.isLinux)
                 ? MediaQuery.of(context).padding.top + Spacing.md
                 : MediaQuery.of(context).padding.top,
         left: Spacing.screenHPadding,


### PR DESCRIPTION
Fixes: #11 

![Screenshot_20230123_205858](https://user-images.githubusercontent.com/15833995/214143706-3ccf5fe1-26d0-4eb4-98fd-3cf5f135ff71.png)
